### PR TITLE
Use existing config

### DIFF
--- a/src/Config/brandenburg.php
+++ b/src/Config/brandenburg.php
@@ -1,8 +1,0 @@
-<?php
-
-return [
-    /**
-     * Brandenburg Package Configuration
-     */
-    'userModel' => env('USER_MODEL', 'App\User')
-];

--- a/src/Providers/BrandenburgServiceProvider.php
+++ b/src/Providers/BrandenburgServiceProvider.php
@@ -19,10 +19,6 @@ class BrandenburgServiceProvider extends ServiceProvider
     {
         $this->loadMigrationsFrom(__DIR__.'/../Database/Migrations');
 
-        $this->publishes([
-            __DIR__.'/../Config/brandenburg.php' => config_path('brandenburg.php'),
-        ]);
-
         $this->registerPolicy();
     }
 
@@ -33,9 +29,7 @@ class BrandenburgServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->mergeConfigFrom(
-            __DIR__.'/../Config/brandenburg.php', 'brandenburg'
-        );
+        //
     }
 
     /**

--- a/src/Role.php
+++ b/src/Role.php
@@ -44,7 +44,7 @@ class Role extends Model
      */
     public function users()
     {
-        return $this->belongsToMany(config('brandenburg.userModel'));
+        return $this->belongsToMany(config('auth.providers.users.model'));
     }
 
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -63,7 +63,7 @@ class TestCase extends OrchestraTestCase
             'prefix'   => '',
         ]);
 
-        $app['config']->set('brandenburg.userModel', 'Silvanite\Brandenburg\Test\User');
+        $app['config']->set('auth.providers.users.model', 'Silvanite\Brandenburg\Test\User');
     }
 
     protected function setupDatabase($app)


### PR DESCRIPTION
Hi there,

I am playing with your nova package, Really like the way permissions are code defined. like it should.

first thing I found was that you use some custom config to point to the user model, this is already defined in the original config, also used by Laravel and Nova for finding the user object.

The other idea i got is for the roles table: add a boolean field `admin` of `full_control` or something, with this boolean you can define a super user who always passes the policies and gates, no need to asign every permissions to the administrator group, example is as follow:

```
Gate::before(function ($user, $ability) {
    if ($user->isSuperAdmin()) {
        return true;
    }
});
```

Documentation: https://laravel.com/docs/5.7/authorization#intercepting-gate-checks

I will check later if i can find more improvements/fixes/whatever

keep up the good work, love the approach