### PR TITLE
Allow to ignore default migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ Three additional tables are required to enable User Roles. These will be install
 php artisan migrate
 ```
 
+If you are not going to use Brandenburg's default migrations, you should change the `ignoreMigrations` option in the configuration file. You may export the default migrations using:
+
+```sh
+php artisan vendor:publish --tag=brandenburg-migrations
+```
+
 ## Usage
 
 This package provides two traits. The main trait is intended for your user model which enabled model relationships.

--- a/src/Config/brandenburg.php
+++ b/src/Config/brandenburg.php
@@ -2,7 +2,12 @@
 
 return [
     /**
-     * Brandenburg Package Configuration
+     * User model class name.
      */
-    'userModel' => env('USER_MODEL', 'App\User')
+    'userModel' => env('USER_MODEL', 'App\User'),
+
+    /**
+     * Configure Brandenburg to not register its migrations.
+     */
+    'ignoreMigrations' => false,
 ];

--- a/src/Database/Migrations/2017_05_28_115649_create_gates_table.php
+++ b/src/Database/Migrations/2017_05_28_115649_create_gates_table.php
@@ -51,8 +51,6 @@ class CreateGatesTable extends Migration
 
             $table->primary(['role_id', 'user_id']);
         });
-
-        
     }
 
     /**

--- a/src/Providers/BrandenburgServiceProvider.php
+++ b/src/Providers/BrandenburgServiceProvider.php
@@ -7,6 +7,7 @@ use Illuminate\Routing\Router;
 use Silvanite\Brandenburg\Policy;
 use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Config\Repository as Config;
 
 class BrandenburgServiceProvider extends ServiceProvider
 {
@@ -17,11 +18,17 @@ class BrandenburgServiceProvider extends ServiceProvider
      */
     public function boot(Router $router, Kernel $kernel)
     {
-        $this->loadMigrationsFrom(__DIR__.'/../Database/Migrations');
-
         $this->publishes([
             __DIR__.'/../Config/brandenburg.php' => config_path('brandenburg.php'),
-        ]);
+        ], 'brandenburg-config');
+
+        if (!$this->app->make(Config::class)->get('brandenburg.ignoreMigrations', false)) {
+            $this->loadMigrationsFrom(__DIR__.'/../Database/Migrations');
+        } else {
+            $this->publishes([
+                __DIR__.'/../Database/Migrations' => database_path('migrations'),
+            ], 'brandenburg-migrations');
+        }
 
         $this->registerPolicy();
     }


### PR DESCRIPTION
You can't run `migrate:refresh` if the user model was created after Brandenburg's default migrations (`2017_05_28_115649_create_gates_table`) because of a non-existent foreign key:

> Illuminate\Database\QueryException  : SQLSTATE[HY000]: General error: 1215 Cannot add foreign key constraint (SQL: alter table `role_user` add constraint `role_user_user_id_foreign` foreign key (`user_id`) references `users` (`id`) on delete cascade)

My solution is a new configuration option called `ignoreMigrations`.

Heavily inspired by Laravel Passport:

https://laravel.com/docs/5.7/passport#installation