### PR TITLE
Fix nobodyHasAccess bug

### DIFF
--- a/src/Permission.php
+++ b/src/Permission.php
@@ -39,7 +39,7 @@ class Permission extends Model
      */
     public function roles()
     {
-        return $this->belongsTo(Role::class, 'role_id');
+        return $this->belongsToMany(Role::class, 'role_permission', 'permission_slug', 'role_id');
     }
 
     /**


### PR DESCRIPTION
I've changed the relationship used by the roles function on the permission model.

This was causing a bug on the nobodyHasAccess feature as only the first associated role was being returned, if this role had no associated users then full permissions were granted.