### PR TITLE
Incorrect return type of roles method in doc block

### DIFF
--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -9,7 +9,7 @@ trait HasRoles
     /**
      * Get all Roles given to this user
      *
-     * @return void
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
      */
     public function roles()
     {


### PR DESCRIPTION
In HasRoles trait, Doc block of roles method should be `\Illuminate\Database\Eloquent\Relations\BelongsToMany`.