### PR TITLE
Timestamps on role_user table

### DIFF
--- a/src/Permission.php
+++ b/src/Permission.php
@@ -35,7 +35,7 @@ class Permission extends Model
     /**
      * Find all roles which have this permission granted
      *
-     * @return void
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
      */
     public function roles()
     {

--- a/src/Role.php
+++ b/src/Role.php
@@ -2,9 +2,10 @@
 
 namespace Silvanite\Brandenburg;
 
-use Silvanite\Brandenburg\Policy;
-use Illuminate\Support\Facades\Gate;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Schema;
+use Silvanite\Brandenburg\Policy;
 
 class Role extends Model
 {
@@ -44,7 +45,13 @@ class Role extends Model
      */
     public function users()
     {
-        return $this->belongsToMany(config('brandenburg.userModel'))->withTimestamps();
+        $users = $this->belongsToMany(config('brandenburg.userModel'));
+
+        if (Schema::hasColumns('role_user', ['created_at', 'updated_at'])) {
+            $users->withTimestamps();
+        }
+
+        return $users;
     }
 
     /**

--- a/src/Role.php
+++ b/src/Role.php
@@ -44,7 +44,7 @@ class Role extends Model
      */
     public function users()
     {
-        return $this->belongsToMany(config('brandenburg.userModel'));
+        return $this->belongsToMany(config('brandenburg.userModel'))->withTimestamps();
     }
 
     /**

--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -13,7 +13,7 @@ trait HasRoles
      */
     public function roles()
     {
-        return $this->belongsToMany(Role::class)->with('getPermissions');
+        return $this->belongsToMany(Role::class)->with('getPermissions')->withTimestamps();
     }
 
     /**

--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -2,6 +2,7 @@
 
 namespace Silvanite\Brandenburg\Traits;
 
+use Illuminate\Support\Facades\Schema;
 use Silvanite\Brandenburg\Role;
 
 trait HasRoles
@@ -13,7 +14,13 @@ trait HasRoles
      */
     public function roles()
     {
-        return $this->belongsToMany(Role::class)->with('getPermissions')->withTimestamps();
+        $roles = $this->belongsToMany(Role::class)->with('getPermissions');
+
+        if (Schema::hasColumns('role_user', ['created_at', 'updated_at'])) {
+            $roles = $roles->withTimestamps();
+        }
+
+        return $roles;
     }
 
     /**


### PR DESCRIPTION
Add timestamps automatically to the pivot table `role_user`. At the moment, when you assign new role to a user, the timestamps on the `role_user` table will be null.